### PR TITLE
Get custom date class name set with Date::use

### DIFF
--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -13,7 +13,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as IlluminateModel;
 use Illuminate\Database\Eloquent\Relations;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionException;
@@ -511,7 +510,7 @@ class DocumentationGenerator
                 continue;
             }
 
-            $types[] = '\\' . Carbon::class;
+            $types[] = '\\' . now()::class;
         }
 
         if (empty($types)) {
@@ -602,7 +601,7 @@ class DocumentationGenerator
             case 'immutable_custom_datetime':
             case 'immutable_datetime':
             case 'timestamp':
-                return '\\' . \Carbon\Carbon::class;
+                return '\\' . now()::class;
         }
 
         return null;

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -510,7 +510,7 @@ class DocumentationGenerator
                 continue;
             }
 
-            $types[] = '\\' . now()::class;
+            $types[] = '\\' . get_class(now());
         }
 
         if (empty($types)) {
@@ -601,7 +601,7 @@ class DocumentationGenerator
             case 'immutable_custom_datetime':
             case 'immutable_datetime':
             case 'timestamp':
-                return '\\' . now()::class;
+                return '\\' . get_class(now());
         }
 
         return null;


### PR DESCRIPTION
We use `Date::use(\Carbon\CarbonImmutable::class)` and that makes `now()` and casting use `CarbonImmutable`. It's not clear how to get the class from the `Date` facade, so we get it by using `now()`.

Laravel provides this feature to customize the date class, but virtually all phpdoc generators don't realize `Carbon` isn't always the date class.