### PR TITLE
Add custom mixin tags

### DIFF
--- a/config/model-doc.php
+++ b/config/model-doc.php
@@ -43,4 +43,11 @@ return [
 
     // Ignore models by FQCN
     'ignore' => [],
+
+    'custom_tags' => [
+        // Add a "@mixin" tag value to support static method linting for IDEs.
+        'mixins' => [
+            // \Illuminate\Database\Eloquent\Model::class,
+        ],
+    ],
 ];

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use romanzipp\ModelDoc\Exceptions\InvalidModelException;
 use romanzipp\ModelDoc\Exceptions\ModelDocumentationFailedException;
 use romanzipp\ModelDoc\Services\Objects\Model;
+use romanzipp\ModelDoc\Services\Tags\MixinTag;
 use Symfony\Component\Finder\Finder;
 
 class DocumentationGenerator
@@ -71,6 +72,12 @@ class DocumentationGenerator
         $tags = [];
 
         $reflectionClass = $model->getReflectionClass();
+
+        if (($mixinClasses = config('model-doc.custom_tags.mixins')) && ! empty($mixinClasses)) {
+            foreach ($mixinClasses as $mixinClass) {
+                $tags[] = new MixinTag($mixinClass);
+            }
+        }
 
         // 1. Generate properties from database columns
 

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -73,7 +73,7 @@ class DocumentationGenerator
 
         $reflectionClass = $model->getReflectionClass();
 
-        if (($mixinClasses = config('model-doc.custom_tags.mixins')) && ! empty($mixinClasses)) {
+        if ($mixinClasses = config('model-doc.custom_tags.mixins')) {
             foreach ($mixinClasses as $mixinClass) {
                 $tags[] = new MixinTag($mixinClass);
             }

--- a/src/Services/Tags/MixinTag.php
+++ b/src/Services/Tags/MixinTag.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace romanzipp\ModelDoc\Services\Tags;
+
+use gossi\docblock\tags\AbstractDescriptionTag;
+
+class MixinTag extends AbstractDescriptionTag
+{
+    public function __construct(string $class)
+    {
+        parent::__construct('mixin', $class);
+    }
+
+    protected function parse(string $content): void
+    {
+        if ('\\' !== substr($content, 0, 1)) {
+            $content = "\\$content";
+        }
+
+        $this->setDescription($content);
+    }
+
+    public function toString(): string
+    {
+        return trim(sprintf('@mixin %s', trim($this->description)));
+    }
+
+    public function getVariable()
+    {
+        return null;
+    }
+}

--- a/src/Services/Tags/MixinTag.php
+++ b/src/Services/Tags/MixinTag.php
@@ -25,7 +25,7 @@ class MixinTag extends AbstractDescriptionTag
         return trim(sprintf('@mixin %s', trim($this->description)));
     }
 
-    public function getVariable()
+    public function getVariable(): ?string
     {
         return null;
     }

--- a/tests/GeneratorCustomTagsTest.php
+++ b/tests/GeneratorCustomTagsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace romanzipp\ModelDoc\Tests;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+use romanzipp\ModelDoc\Services\DocumentationGenerator;
+use romanzipp\ModelDoc\Tests\Support\Files\Model;
+
+class GeneratorCustomTagsTest extends TestCase
+{
+    public function testEmptyMixin()
+    {
+        config([
+            'model-doc.custom_tags.mixins' => [],
+        ]);
+
+        $doc = (new DocumentationGenerator())->generateDocBlock(new \romanzipp\ModelDoc\Services\Objects\Model(
+            $this->getFile(__DIR__ . '/Support/ModelEmpty.php')
+        ));
+
+        self::assertDocBlock([
+            '/**',
+            ' * @property int $id',
+            ' */',
+        ], $doc);
+    }
+
+    public function testSingleMixin()
+    {
+        config([
+            'model-doc.custom_tags.mixins' => [
+                EloquentModel::class,
+            ],
+        ]);
+
+        $doc = (new DocumentationGenerator())->generateDocBlock(new \romanzipp\ModelDoc\Services\Objects\Model(
+            $this->getFile(__DIR__ . '/Support/ModelEmpty.php')
+        ));
+
+        self::assertDocBlock([
+            '/**',
+            ' * @mixin \Illuminate\Database\Eloquent\Model',
+            ' * @property int $id',
+            ' */',
+        ], $doc);
+    }
+
+    public function testMultipleMixins()
+    {
+        config([
+            'model-doc.custom_tags.mixins' => [
+                EloquentModel::class,
+                Model::class,
+            ],
+        ]);
+
+        $doc = (new DocumentationGenerator())->generateDocBlock(new \romanzipp\ModelDoc\Services\Objects\Model(
+            $this->getFile(__DIR__ . '/Support/ModelEmpty.php')
+        ));
+
+        self::assertDocBlock([
+            '/**',
+            ' * @mixin \Illuminate\Database\Eloquent\Model',
+            ' * @mixin \romanzipp\ModelDoc\Tests\Support\Files\Model',
+            ' * @property int $id',
+            ' */',
+        ], $doc);
+    }
+}

--- a/tests/Support/ModelEmpty.php
+++ b/tests/Support/ModelEmpty.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace romanzipp\ModelDoc\Tests\Support;
+
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class ModelEmpty extends EloquentModel
+{
+    protected $table = 'table_empty';
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,6 +48,10 @@ class TestCase extends BaseTestCase
         $app['db']->connection()->getSchemaBuilder()->create('table_special', function (Blueprint $table) {
             $table->enum('column_enum', ['one', 'two']);
         });
+
+        $app['db']->connection()->getSchemaBuilder()->create('table_empty', function (Blueprint $table) {
+            $table->increments('id');
+        });
     }
 
     protected static function assertDocBlock(array $expected, Docblock $actual): void


### PR DESCRIPTION
Resolves #12 

New config value

```
    'custom_tags' => [
        // Add a "@mixin" tag value to support static method linting for IDEs.
        'mixins' => [
            // \Illuminate\Database\Eloquent\Model::class,
        ],
    ],
```