### PR TITLE
Support for Attribute casts

### DIFF
--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -279,9 +279,13 @@ class DocumentationGenerator
                 $returnType = $typeReturn;
             }
 
-            $tag->setType($returnType);
+            $camelCaseTag->setType($returnType);
 
-            yield $tag;
+            $snakeCaseTag = clone $camelCaseTag;
+            $snakeCaseTag->setVariable(Str::snake($methodName));
+
+            yield $camelCaseTag;
+            yield $snakeCaseTag;
         }
     }
 

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -257,6 +257,10 @@ class DocumentationGenerator
                 continue;
             }
 
+            if ( ! $method->isPublic() ) {
+                continue;
+            }
+
             /** @var ?callable $get */
             $get = $model->{$method->getName()}()->get;
 
@@ -268,7 +272,6 @@ class DocumentationGenerator
             $tag->setVariable(Str::snake($method->getName()));
 
             $returnType = 'mixed';
-
 
             $callableFunction = new \ReflectionFunction($get);
 

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -258,11 +258,11 @@ class DocumentationGenerator
             }
 
             if ( ! $method->isPublic() ) {
-                continue;
+                $method->setAccessible(true);
             }
 
             /** @var ?callable $get */
-            $get = $model->{$method->getName()}()->get;
+            $get = $method->invoke($model)?->get;
 
             if ($get === null) {
                 continue;

--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -268,8 +268,8 @@ class DocumentationGenerator
                 continue;
             }
 
-            $tag = new PropertyTag();
-            $tag->setVariable(Str::snake($method->getName()));
+            $camelCaseTag = new PropertyTag();
+            $camelCaseTag->setVariable($methodName = $method->getName());
 
             $returnType = 'mixed';
 

--- a/tests/ModelGeneratorAccessorsTest.php
+++ b/tests/ModelGeneratorAccessorsTest.php
@@ -68,12 +68,18 @@ class ModelGeneratorAccessorsTest extends TestCase
 
         self::assertDocBlock([
             '/**',
+            ' * @property mixed $getOnly',
             ' * @property mixed $get_only',
             ' * @property mixed $untyped',
+            ' * @property string $someString',
             ' * @property string $some_string',
+            ' * @property int $someInt',
             ' * @property int $some_int',
+            ' * @property array $someArray',
             ' * @property array $some_array',
+            ' * @property \romanzipp\ModelDoc\Tests\Support\ClassNotExtendingIlluminateModel $someInstance',
             ' * @property \romanzipp\ModelDoc\Tests\Support\ClassNotExtendingIlluminateModel $some_instance',
+            ' * @property string $parentDefinition',
             ' * @property string $parent_definition',
             ' */',
         ], $doc);

--- a/tests/ModelGeneratorAccessorsTest.php
+++ b/tests/ModelGeneratorAccessorsTest.php
@@ -74,6 +74,7 @@ class ModelGeneratorAccessorsTest extends TestCase
             ' * @property int $some_int',
             ' * @property array $some_array',
             ' * @property \romanzipp\ModelDoc\Tests\Support\ClassNotExtendingIlluminateModel $some_instance',
+            ' * @property string $parent_definition',
             ' */',
         ], $doc);
     }

--- a/tests/ModelGeneratorAccessorsTest.php
+++ b/tests/ModelGeneratorAccessorsTest.php
@@ -53,4 +53,27 @@ class ModelGeneratorAccessorsTest extends TestCase
             ' */',
         ], $doc);
     }
+
+    public function testAttributeAccessor()
+    {
+        config([
+            'model-doc.relations.enabled' => false,
+            'model-doc.attributes.enabled' => false,
+            'model-doc.accessors.enabled' => true,
+        ]);
+
+        $doc = (new DocumentationGenerator())->generateModelDocBlock(new Model(
+            $this->getFile(__DIR__ . '/Support/ModelAttributeCast.php')
+        ));
+
+        self::assertDocBlock([
+            '/**',
+            ' * @property mixed $untyped',
+            ' * @property string $some_string',
+            ' * @property int $some_int',
+            ' * @property array $some_array',
+            ' * @property \romanzipp\ModelDoc\Tests\Support\ClassNotExtendingIlluminateModel $some_instance',
+            ' */',
+        ], $doc);
+    }
 }

--- a/tests/ModelGeneratorAccessorsTest.php
+++ b/tests/ModelGeneratorAccessorsTest.php
@@ -68,6 +68,7 @@ class ModelGeneratorAccessorsTest extends TestCase
 
         self::assertDocBlock([
             '/**',
+            ' * @property mixed $get_only',
             ' * @property mixed $untyped',
             ' * @property string $some_string',
             ' * @property int $some_int',

--- a/tests/Support/ModelAttributeCast.php
+++ b/tests/Support/ModelAttributeCast.php
@@ -16,6 +16,13 @@ class ModelAttributeCast extends EloquentModel
         );
     }
 
+    public function getOnly(): Attribute
+    {
+        return Attribute::get(function() {
+            return '';
+        });
+    }
+
     public function untyped(): Attribute
     {
         return Attribute::make(

--- a/tests/Support/ModelAttributeCast.php
+++ b/tests/Support/ModelAttributeCast.php
@@ -3,12 +3,9 @@
 namespace romanzipp\ModelDoc\Tests\Support;
 
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Model as EloquentModel;
 
-class ModelAttributeCast extends EloquentModel
+class ModelAttributeCast extends ModelParent
 {
-    protected $table = 'table_one';
-
     public function setOnly(): Attribute
     {
         return Attribute::make(

--- a/tests/Support/ModelAttributeCast.php
+++ b/tests/Support/ModelAttributeCast.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace romanzipp\ModelDoc\Tests\Support;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class ModelAttributeCast extends EloquentModel
+{
+    protected $table = 'table_one';
+
+    public function setOnly(): Attribute
+    {
+        return Attribute::make(
+            set: fn ($value) => $value,
+        );
+    }
+
+    public function untyped(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value,
+        );
+    }
+
+    public function someString(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => $value,
+        );
+    }
+
+    public function someInt(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): int => $value,
+        );
+    }
+
+    public function someArray(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value): array => $value,
+        );
+    }
+
+    public function someInstance(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value): ClassNotExtendingIlluminateModel => $value,
+        );
+    }
+}

--- a/tests/Support/ModelParent.php
+++ b/tests/Support/ModelParent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace romanzipp\ModelDoc\Tests\Support;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
+
+class ModelParent extends EloquentModel
+{
+    protected $table = 'table_one';
+
+    protected function parentDefinition(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value): string => $value,
+        );
+    }
+}


### PR DESCRIPTION
This PR adds support for Eloquent accessor type introduced in Laravel 9.x.

Style / naming might need some updating, but it works functionally :)