### PR TITLE
Document fallback_type

### DIFF
--- a/config/model-doc.php
+++ b/config/model-doc.php
@@ -20,7 +20,9 @@ return [
     'attributes' => [
         'enabled' => true,
 
-        // Use dbal class type if col type not mapped
+        // Use any class or PHP native type as a fallback for column types that cannot be resolved
+        // Examples: "string", "int", \App\Database\MyCustomFallbackType::class
+        // If false the type will be set to "mixed"
         'fallback_type' => false,
     ],
 

--- a/tests/ModelGeneratorAttributesTest.php
+++ b/tests/ModelGeneratorAttributesTest.php
@@ -51,6 +51,7 @@ class ModelGeneratorAttributesTest extends TestCase
             ' * @property string $column_ulid',
             ' * @property string $column_ip_address',
             ' * @property string $column_mac_address',
+            ' * @property ' . Support\Files\Model::class . ' $column_custom_fallback',
             ' */',
         ], $doc);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,6 +19,7 @@ class TestCase extends BaseTestCase
             'model-doc.relations.counts.enabled' => true,
             'model-doc.attributes.enabled' => true,
             'model-doc.tag_sorting' => [],
+            'model-doc.attributes.fallback_type' => Support\Files\Model::class,
         ]);
 
         $this->setupDatabase($this->app);
@@ -70,6 +71,8 @@ class TestCase extends BaseTestCase
             $table->ipAddress('column_ip_address');
             $table->macAddress('column_mac_address');
         });
+
+        $app['db']->connection()->statement('ALTER TABLE table_extended ADD COLUMN column_custom_fallback custom_type NOT NULL');
 
         $app['db']->connection()->getSchemaBuilder()->create('table_special', function (Blueprint $table) {
             $table->enum('column_enum', ['one', 'two']);


### PR DESCRIPTION
Adds documentation and test for custom fallback type.

Tests for MySQL are breaking because MySQL doesn't support custom types.
I could either add checks where necessary or remove the test altogether.
