### PR TITLE
Normalize line endings in DocumentationGenerator and TestCase to use "\n"

### DIFF
--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -485,7 +485,7 @@ class DocumentationGenerator
 
         $lineIndexClassDeclaration = null;
 
-        $lines = explode(PHP_EOL, $content);
+        $lines = explode("\n", $content);
 
         foreach ($lines as $index => $line) {
             if ( ! preg_match('/^(abstract|final)? ?class ([A-z]+)/', $line)) {
@@ -514,7 +514,7 @@ class DocumentationGenerator
             $lines[$index] = null;
         }
 
-        $docLines = explode(PHP_EOL, $docblock->toString());
+        $docLines = explode("\n", $docblock->toString());
 
         foreach (array_reverse($docLines) as $docLine) {
             array_splice($lines, $lineIndexClassDeclaration, 0, $docLine);
@@ -522,7 +522,7 @@ class DocumentationGenerator
 
         $lines = array_filter($lines, static fn ($line) => null !== $line);
 
-        file_put_contents($reflectionClass->getFileName(), implode(PHP_EOL, $lines));
+        file_put_contents($reflectionClass->getFileName(), implode("\n", $lines));
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,9 +82,9 @@ class TestCase extends BaseTestCase
 
     protected static function assertDocBlock(array $expected, Docblock $actual): void
     {
-        self::assertSame(implode(PHP_EOL, $expected), $actual->toString());
+        self::assertSame(implode("\n", $expected), $actual->toString());
 
-        $actualLines = explode(PHP_EOL, $actual->toString());
+        $actualLines = explode("\n", $actual->toString());
 
         foreach ($expected as $index => $line) {
             self::assertSame($line, $actualLines[$index]);


### PR DESCRIPTION
Hi, I'm using Windows, but my codebase uses \n line endings, instead of the Windows default of \r\n. Therefore, when running `php artisan model-doc:generate`, I get "Failed: ... Can not find class declaration" for each model.

Your `DocumentGenerator` function `writeDoc`, currently uses `PHP_EOL` to split the lines. I think it is safer to user `\n` for this. In the same function you also split `$docblock` by `PHP_EOL`, but docblock was generated using `\n`.

In this PR I changed `PHP_EOL` into `\n` in th DocumentatoinGenerator and TestCase.