### PR TITLE
Update DocumentationGenerator.php

### DIFF
--- a/src/Services/DocumentationGenerator.php
+++ b/src/Services/DocumentationGenerator.php
@@ -271,10 +271,6 @@ class DocumentationGenerator
                 continue;
             }
 
-            if ( ! $method->isPublic()) {
-                $method->setAccessible(true);
-            }
-
             /** @var ?callable $get */
             $get = $method->invoke($model)?->get;
 


### PR DESCRIPTION
ErrorException: Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1 in /var/www/html/vendor/romanzipp/laravel-model-doc/src/Services/DocumentationGenerator.php:275